### PR TITLE
Adopt xformers attention for better performance

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -290,6 +290,7 @@ class Attention(nn.Module):
                 )
 
         output = output.contiguous().view(bsz, seqlen, -1)
+        return output
 
     def forward(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 fairscale
 fire
 sentencepiece
+xformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ torch
 fairscale
 fire
 sentencepiece
-xformers


### PR DESCRIPTION
Simply replaced the trivial implementation of attention in ```Attention``` class with xformers ```memory_efficient_attention``` implementation. Performance test for 13B model inference on single A100 shows ~40% increase.