### PR TITLE
README: Update repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ## **Note of deprecation**
 
 Thank you for developing with Llama models. As part of the Llama 3.1 release, we’ve consolidated GitHub repos and added some additional repos as we’ve expanded Llama’s functionality into being an e2e Llama Stack. Please use the following repos going forward:
-- [llama-models](https://github.com/meta-llama/llama-models) - Central repo for the foundation models including basic utilities, model cards, license and use policies
-- [PurpleLlama](https://github.com/meta-llama/PurpleLlama) - Key component of Llama Stack focusing on safety risks and inference time mitigations 
-- [llama-toolchain](https://github.com/meta-llama/llama-toolchain) - Model development (inference/fine-tuning/safety shields/synthetic data generation) interfaces and canonical implementations
-- [llama-agentic-system](https://github.com/meta-llama/llama-agentic-system) - E2E standalone Llama Stack system, along with opinionated underlying interface, that enables creation of agentic applications
-- [llama-recipes](https://github.com/meta-llama/llama-recipes) - Community driven scripts and integrations
+- [llama-models](https://github.com/meta-llama/llama-models) - Central repo for the foundation models including basic utilities, model cards, license and use policies.
+- [PurpleLlama](https://github.com/meta-llama/PurpleLlama) - Key component of Llama Stack focusing on safety risks and inference time mitigations.
+- [llama-stack](https://github.com/meta-llama/llama-stack) - Building blocks that span the entire development lifecycle: model training and fine-tuning, product evaluation, building and running AI agents in production.
+- [llama-agentic-system](https://github.com/meta-llama/llama-agentic-system) - Agentic components of the Llama Stack APIs.
+- [llama-recipes](https://github.com/meta-llama/llama-recipes) - Community driven scripts and integrations.
 
 If you have any questions, please feel free to file an issue on any of the above repos and we will do our best to respond in a timely manner. 
 


### PR DESCRIPTION
`llama-toolchain` now redirects to `llama-stack`. Slightly reworded a couple of descriptions to bring them more in line with the new repo structure.